### PR TITLE
service has to be unregistered if it goes down

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,5 @@ eureka.client.enabled=${ACT_REGISTRY_EUREKA_CLIENT_ENABLED:true}
 
 # to use git pass env var SPRING_PROFILES_ACTIVE=git
 spring.profiles.active=native
+
+eureka.server.enable-self-preservation=false


### PR DESCRIPTION
I tested it locally, now I can see those logs in the registry:
```
DS: Registry: expired lease for QUERY/activiti-cloud-query-7fcd59fbb6-6j65w:query:8182
INFO 6 --- [a-EvictionTimer] c.n.e.registry.AbstractInstanceRegistry  : Cancelled instance QUERY/activiti-cloud-query-7fcd59fbb6-6j65w:query:8182 (replication=false)
```
and the service disappears after some time from this endpoint:
```
/actuator/routes
```